### PR TITLE
[ST-19] Fixed Deserializer unity lifetime

### DIFF
--- a/Assets/Scripts/General/Deserializer.cs
+++ b/Assets/Scripts/General/Deserializer.cs
@@ -10,11 +10,9 @@ public class Deserializer<T>
   public Deserializer(string resourcesApiPath)
   {
     this.resourcesApiPath = resourcesApiPath;
-    ResourcesAPILoader();
-    GetDeserializedObject();
   }
 
-  protected void ResourcesAPILoader()
+  public void ResourcesAPILoader()
   {
     jsonTextFile = Resources.Load<TextAsset>(resourcesApiPath);
   }
@@ -23,7 +21,7 @@ public class Deserializer<T>
   {
     if (jsonTextFile == null)
     {
-      throw new Exception("No JSON file assigned");
+      throw new Exception($"No JSON file assigned -- or you forgot to call {this}.ResourcesAPILoader()");
     }
     if (deserializedObject == null)
     {

--- a/Assets/Testing/Runtime/Dialog/DialogDeserializer_SceneTests.cs
+++ b/Assets/Testing/Runtime/Dialog/DialogDeserializer_SceneTests.cs
@@ -17,6 +17,7 @@ public class DialogDeserializer_CurrentScene
     yield return null;
     currentScene = SceneManager.GetActiveScene();
     dialogDeserializer = new DialogDeserializer($"DialogData/{currentScene.name}");
+    dialogDeserializer.ResourcesAPILoader();
   }
 
   [UnityTest]

--- a/Assets/Testing/Runtime/General/Deserializer_HandlesJson.cs
+++ b/Assets/Testing/Runtime/General/Deserializer_HandlesJson.cs
@@ -13,6 +13,7 @@ public class Deserializer_HandlesJson
     Type expectedType = type;
     Type actualType;
     Deserializer<DialogData> deserializer = new(jsonResourceAPIpath);
+    deserializer.ResourcesAPILoader();
     var jsonTextFile = deserializer.GetCurrentlyAssignedJson();
 
     //Act
@@ -27,6 +28,7 @@ public class Deserializer_HandlesJson
   {
     //Arrange
     Deserializer<DialogData> deserializer = new(jsonResourceAPIpath);
+    deserializer.ResourcesAPILoader();
     var jsonTextFile = deserializer.GetCurrentlyAssignedJson();
     //Act
     var deserializedObject = deserializer.GetDeserializedObject();


### PR DESCRIPTION
Resources.Load(); can’t be called from a constructor. Unity hasn’t properly registered the class and it already tries to access it’s resources